### PR TITLE
Removed glob when called from CLI

### DIFF
--- a/virustotal.py
+++ b/virustotal.py
@@ -329,7 +329,7 @@ A resource can be:
         print "ERROR: unknown action"
         return -1
 
-    v = VirusTotal(API_KEY, limit_per_min = int(options.limit_per_min))
+    v = VirusTotal(api_key, limit_per_min = int(options.limit_per_min))
 
     q = Queue.Queue()
     def analyze(resource):


### PR DESCRIPTION
glob.glob() does not work when passing an URL or an hash to scan mode.

I think this is the expected behaviour:

```
python virustotal.py get ~/path/to/file/a0360c3e3e5d86f4e590c11946b359ed 
=== ~/path/to/file/a0360c3e3e5d86f4e590c11946b359ed ===
Report:
- MicroWorld-eScan (12.0.250.0, 20130729):      Trojan.Generic.KDV.522400
- nProtect (2013-07-29.01, 20130729):   Trojan-Spy/W32.ZBot.182272.AC
- CAT-QuickHeal (12.00, 20130729):      TrojanPWS.Zbot.Gen
...
```

Otherwise, the scanner does nothing:

```
python virustotal.py get a0360c3e3e5d86f4e590c11946b359ed 
```
