### PR TITLE
Cannot pass Windows paths.  urlparse will find a scheme and interpret as a URL

### DIFF
--- a/virustotal.py
+++ b/virustotal.py
@@ -130,7 +130,7 @@ class VirusTotal(object):
                 return ["resource", anything, filename]
 
             # Is URL ?
-            if urlparse.urlparse(anything).scheme:
+            if urlparse.urlparse(anything).netloc:
                 fh = urllib2.urlopen(anything)
 
             else:


### PR DESCRIPTION
> > > import urlparse
> > > path = "C:\Users\careyh\VT-scanner\tmpavg8j8\batch-0-IDE-8.5.3-83203.zip"
> > > urlparse.urlparse(path)
> > > ParseResult(scheme='c', netloc='', path='\Users\careyh\VT-scanner\tmpavg8j8\x
> > > 08atch-0-IDE-8.5.3-83203.zip', params='', query='', fragment='')
> > > url = "http://bugs.activestate.com/"
> > > urlparse.urlparse(url)
> > > ParseResult(scheme='http', netloc='bugs.activestate.com', path='/', params='', q
> > > uery='', fragment='')

Based on that, switching to netloc seemed safe.  Checked on Ubuntu 13.10:

> > > import urlparse
> > > import os
> > > urlparse.urlparse(os.getcwd())
> > > ParseResult(scheme='', netloc='', path='/home/qatest/virustotal', params='', query='', fragment='')
